### PR TITLE
Pi5 serial support

### DIFF
--- a/modules/asl3/filesystem/etc/motd.d/asl3-firstboot
+++ b/modules/asl3/filesystem/etc/motd.d/asl3-firstboot
@@ -1,0 +1,9 @@
+===== ===== ===== ===== ===== ===== ===== ===== =====
+
+ NOTE: THIS SYSTEM IS CURRENTLY PERFORMING INITIAL
+       PACKAGE UPDATES, SETUP, AND CONFIGURATION.
+
+       WHEN COMPLETE, THE SYSTEM WILL REBOOT.
+
+===== ===== ===== ===== ===== ===== ===== ===== =====
+

--- a/modules/asl3/filesystem/etc/systemd/system/asl3-firstboot-complete.service
+++ b/modules/asl3/filesystem/etc/systemd/system/asl3-firstboot-complete.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Reboot system after firstboot services have finished
+After=asl3-firstboot.service asl3-firstboot-pkg-updates.service
+Requires=asl3-firstboot.service asl3-firstboot-pkg-updates.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/asl3-firstboot-complete
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/modules/asl3/filesystem/usr/local/sbin/asl3-firstboot
+++ b/modules/asl3/filesystem/usr/local/sbin/asl3-firstboot
@@ -3,19 +3,20 @@
 if [ -e /asl3-first-boot-needed ]; then
 	rm /asl3-first-boot-needed
 
-	# Regenerate the snakeoil certificate	
 	THISHOST=$(hostnamectl hostname)
+
+	# Regenerate the snakeoil certificate
 	openssl req -x509 -nodes -days 3650 -newkey rsa:2048 \
-	    -keyout /etc/ssl/private/ssl-cert-snakeoil.key \
-    	-out /etc/ssl/certs/ssl-cert-snakeoil.pem -subj \
+		-keyout /etc/ssl/private/ssl-cert-snakeoil.key \
+		-out /etc/ssl/certs/ssl-cert-snakeoil.pem -subj \
 		"/CN=${THISHOST}.local"
 	systemctl restart apache2
 
 	# Regenerate the Cockpit certificate
 	openssl req -x509 -nodes -days 3650 -newkey rsa:2048 \
-        -keyout /etc/cockpit/ws-certs.d/0-self-signed.key \
-        -out /etc/cockpit/ws-certs.d/0-self-signed.cert -subj \
-        "/CN=${THISHOST}.local"
+		-keyout /etc/cockpit/ws-certs.d/0-self-signed.key \
+		-out /etc/cockpit/ws-certs.d/0-self-signed.cert -subj \
+		"/CN=${THISHOST}.local"
 
 	# Configure manager for Allmon
 	MGR_PWD=$(openssl rand -hex 8)
@@ -30,7 +31,8 @@ EOF
 	# Enable /dev/serial0
 	raspi-config nonint do_serial_hw 0
 	raspi-config nonint do_serial_cons 1
-
-	# Disable firstboot
-	systemctl disable asl3-firstboot
 fi
+
+# Disable service
+systemctl disable asl3-firstboot
+

--- a/modules/asl3/filesystem/usr/local/sbin/asl3-firstboot-complete
+++ b/modules/asl3/filesystem/usr/local/sbin/asl3-firstboot-complete
@@ -1,0 +1,11 @@
+#!/usr/bin/bash
+
+# Remove our early boot "message of the day"
+rm -f /etc/motd.d/asl3-firstboot
+
+# Disable service
+systemctl disable asl3-firstboot-complete
+
+# Reboot (after other firstboot services have completed)
+systemctl reboot
+

--- a/modules/asl3/filesystem/usr/local/sbin/asl3-firstboot-pkg-updates
+++ b/modules/asl3/filesystem/usr/local/sbin/asl3-firstboot-pkg-updates
@@ -4,5 +4,5 @@
 DEBIAN_FRONTEND=noninteractive apt update -y
 DEBIAN_FRONTEND=noninteractive apt dist-upgrade -y
 
-# Disable firstboot
+# Disable service
 systemctl disable asl3-firstboot-pkg-updates

--- a/modules/asl3/start_chroot_script
+++ b/modules/asl3/start_chroot_script
@@ -49,6 +49,7 @@ touch /asl3-first-boot-needed
 systemctl enable systemd-time-wait-sync.service
 systemctl enable asl3-firstboot
 systemctl enable asl3-firstboot-pkg-updates
+systemctl enable asl3-firstboot-complete
 
 # Disk IO minimization
 rm -f /var/log/apache2/*
@@ -69,7 +70,15 @@ tmpfs	/var/log/apache2	tmpfs	defaults,noatime,nosuid,nodev,noexec,mode=0775,size
 tmpfs	/var/log/asterisk	tmpfs	defaults,noatime,nosuid,nodev,noexec,mode=0775,size=32M,uid=${AST_UID},gid=${AST_GID} 0 0 
 EOF
 
-# Disable bluetooth for GPIO accessibility
-echo "dtoverlay=disable-bt" >> /boot/firmware/config.txt
+## For GPIO accessibility, enable serial and disable bluetooth
+cat - >> /boot/firmware/config.txt <<EOF
+# ------------ Universal serial port on pins 8 / 10 -------------
+[all]                     # applies to every Raspberry Pi model
+enable_uart=1             # guarantees /dev/serial0 is created
+dtoverlay=disable-bt      # kills the on-board BT radio
+#  (on Pi 5 this is transparently remapped to the
+#   Pi-5-specific overlay “disable-bt-pi5”)
+# ---------------------------------------------------------------
 
+EOF
 


### PR DESCRIPTION
Update the bootloader configuration to enable PiHat's that use pins 8/10 to be accessible via "/dev/serial0" on [pi3], [pi4], [pi5], and [pi0] devices.